### PR TITLE
chore(deps): group Dependabot patch and minor updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,21 @@ updates:
     versioning-strategy: increase-if-necessary
     commit-message:
       prefix: "chore(deps)"
+    groups:
+      production-minor-patch:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+      development-minor-patch:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+    ignore:
+      - dependency-name: tailwind-merge
+        update-types:
+          - version-update:semver-major
 
   - package-ecosystem: github-actions
     directory: /
@@ -23,3 +38,7 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: "chore(ci)"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

- Group weekly npm patch and minor updates into separate production and development Dependabot PRs, so routine bumps stop crowding the open-PR limit.
- Group all GitHub Actions updates into one PR.
- Ignore `tailwind-merge` major updates because v3 requires Tailwind v4 and this repo stays on Tailwind 3.4. Other majors still open as individual PRs.

## Validation

- [x] `npm test` — N/A: YAML-only Dependabot config change
- [x] `npm run typecheck` — N/A
- [x] `npm run lint` — N/A
- [x] `npm run verify:architecture` — N/A
- [x] `npm run build` — N/A
- [x] `npm run doctor` — pre-commit `doctor:staged` ran (no staged source files)

## Risk and operations

- [x] I did not include credentials, tokens, personal data, or production configuration.
- [x] I described any database, authentication, payment, email, or deployment impact. None: Dependabot grouping only.
- [x] I did not run a database cutover, mutate hosted data, or change an external service as part of this PR.
- [x] I added or updated tests when the behavior changed. N/A: config-only.
- [x] I updated documentation when setup or public behavior changed. N/A.

## Screenshots

N/A — Dependabot config only.


Made with [Cursor](https://cursor.com)