### PR TITLE
fix(ci): remove ai-cli so npm audit can pass

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,6 @@
         "@types/react": "19.2.2",
         "@types/react-dom": "^19.2.2",
         "agent-browser": "^0.32.1",
-        "ai-cli": "^0.4.2",
         "drizzle-kit": "0.31.10",
         "emulate": "^0.9.0",
         "eslint": "9.39.1",
@@ -76,63 +75,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/@ai-sdk/gateway": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.3.tgz",
-      "integrity": "sha512-V8p0skqA9I5ZvZ4JDrvdh+TrZ0OVvkoP4CPEMxy777yBcVO5febhtLUJ+t0V0ROvSIkWIm5R9nvyOsyZRtO9sQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "4.0.0",
-        "@ai-sdk/provider-utils": "5.0.0",
-        "@vercel/oidc": "3.2.0"
-      },
-      "engines": {
-        "node": ">=22"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "node_modules/@ai-sdk/provider": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.0.tgz",
-      "integrity": "sha512-fr9Gs89prDWiuox/T+kCA+i2cJkHpxU5S+tr4megjTzRC27ZsvFhwjU/+XrqqMbvBUlfmXxTOYWy8ng45dsjIg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@ai-sdk/provider-utils": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.0.tgz",
-      "integrity": "sha512-zj66M02jc6ASYwIgWZowsooDUwaVngeNZQ3H10GwcPMZ+KR6gHMhcUuKl6tkai+JPXTKDyHY1pnszuxRtw2D4A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "4.0.0",
-        "@standard-schema/spec": "^1.1.0",
-        "@workflow/serde": "4.1.0",
-        "eventsource-parser": "^3.0.8"
-      },
-      "engines": {
-        "node": ">=22"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "node_modules/@ai-sdk/provider-utils/node_modules/@workflow/serde": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0.tgz",
-      "integrity": "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==",
-      "dev": true,
-      "license": "Apache-2.0"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -6407,16 +6349,6 @@
         "node": ">=14.6"
       }
     },
-    "node_modules/@vercel/oidc": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
-      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 20"
-      }
-    },
     "node_modules/@vercel/speed-insights": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-1.2.0.tgz",
@@ -6541,52 +6473,6 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/ai": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.3.tgz",
-      "integrity": "sha512-ze2nTtoNW1hYhkjAVUVoLQGC/vDmNv+nIo3n8aCv2QQS8WCuC8o3CF6ywnUlui/i7lfGU4V8aPClVRH62WUHeA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/gateway": "4.0.3",
-        "@ai-sdk/provider": "4.0.0",
-        "@ai-sdk/provider-utils": "5.0.0"
-      },
-      "engines": {
-        "node": ">=22"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "node_modules/ai-cli": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/ai-cli/-/ai-cli-0.4.2.tgz",
-      "integrity": "sha512-tDaumzJI5GFYhg4sD8c7a9quAM6w7btlVrsEdbKImuH2GoFT/uz4JgJFnJUy4QYI38O+2QMQjMuufwaXnoqlVw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/gateway": "4.0.3",
-        "ai": "7.0.3",
-        "commander": "^14.0.3"
-      },
-      "bin": {
-        "ai": "dist/index.js"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/ai-cli/node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
       }
     },
     "node_modules/ajv": {
@@ -8910,16 +8796,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/eventsource-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
-      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -10105,13 +9981,6 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/json-schema": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "dev": true,
-      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "@types/react": "19.2.2",
     "@types/react-dom": "^19.2.2",
     "agent-browser": "^0.32.1",
-    "ai-cli": "^0.4.2",
     "drizzle-kit": "0.31.10",
     "emulate": "^0.9.0",
     "eslint": "9.39.1",


### PR DESCRIPTION
## Summary

Master `CI / quality` fails on `npm audit --audit-level=low` because `ai-cli` `>= 0.4.0` pulls `@ai-sdk/provider-utils@5.0.0` (GHSA-866g-f22w-33x8). Latest `ai-cli@0.4.4` still pins the same vulnerable `ai@7.0.3` / `@ai-sdk/gateway@4.0.3` tree, so this drops the local-only CLI from `devDependencies`. The `$ai-cli` skill stays; the binary can still be invoked with `npx` when needed.

## Validation

- [x] `npm audit --audit-level=low` (0 vulnerabilities)
- [x] `npm audit --omit=dev --audit-level=low` (0 vulnerabilities)
- [ ] `npm test` — no app code change; CI quality job covers this
- [ ] `npm run typecheck` — no app code change; CI quality job covers this
- [ ] `npm run lint` — no app code change; CI quality job covers this
- [ ] `npm run verify:architecture` — no app code change; CI quality job covers this
- [ ] `npm run build` — no app code change; CI quality job covers this
- [ ] `npm run doctor` — no app source files changed

## Risk and operations

- [x] I did not include credentials, tokens, personal data, or production configuration.
- [x] I described any database, authentication, payment, email, or deployment impact.
- [x] I did not run a database cutover, mutate hosted data, or change an external service as part of this PR.
- [x] I added or updated tests when the behavior changed.
- [x] I updated documentation when setup or public behavior changed.

No production, database, or app runtime impact. `ai-cli` was unused by the store app and by CI except as an audit failure.

## Screenshots

N/A — dependency-only change.


Made with [Cursor](https://cursor.com)